### PR TITLE
Add Support for Dynamic URL Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ myself.
 
 * Strict typing across the entire codebase
 * Simple `Router` with support for `GET`, `POST`, `PUT`, `PATCH`, `DELETE`
+* **Dynamic URL parameters** (e.g., `/users/{id}`)
 * Request and Response abstractions
 * Contracts for request handlers
 * Exceptions for error handling (`NotFound`, etc.)
@@ -20,7 +21,6 @@ myself.
 
 ## 🔮 Coming soon
 
-* URL params
 * Middleware
 * Validation
 * And more ...
@@ -81,22 +81,24 @@ return function (Router $router) {
 };
 ```
 
-Inside `app/Routes/api.php`:
+### Defining Routes with Parameters
+
+You can define dynamic segments in your routes by wrapping a parameter name in curly braces `{}`. The router will
+automatically extract the value from the URL.
 
 ```php
 use Infra\Http\Router;
 use App\Handlers\UserHandler;
-use App\Handlers\PostHandler;
 
 return function (Router $router) {
-    $router->get('/api/test', new TestHandler);
-    $router->post('/api/post', new PostHandler);
+    // This route will match URLs like /users/42 or /users/clebson
+    $router->get('/users/{id}', new UserHandler);
 };
 ```
 
 ### Writing a Handler
 
-All handlers implement `RequestHandlerInterface`:
+All handlers implement `RequestHandlerInterface`. You can access route parameters from the `Request` object.
 
 ```php
 namespace App\Handlers;
@@ -105,11 +107,14 @@ use Infra\Http\Request;
 use Infra\Http\Response;
 use Infra\Interfaces\RequestHandlerInterface;
 
-class HomeHandler implements RequestHandlerInterface
+class UserHandler implements RequestHandlerInterface
 {
     public function handle(Request $request): Response
     {
-        return new Response::html('<p>Hello from Hard!<p>');
+        // Retrieve the 'id' parameter from the URL
+        $userId = $request->getParam('id');
+
+        return new Response::html("<p>Showing user: {$userId}<p>");
     }
 }
 ```

--- a/app/Handlers/Api/PostHandler.php
+++ b/app/Handlers/Api/PostHandler.php
@@ -12,6 +12,9 @@ class PostHandler implements RequestHandlerInterface
 {
     public function handle(Request $request): Response
     {
-        return Response::json($request->toArray());
+        return Response::json([
+            'data' => $request->toArray(),
+            'params' => $request->getParams(),
+        ]);
     }
 }

--- a/app/Routes/api.php
+++ b/app/Routes/api.php
@@ -6,5 +6,5 @@ use App\Handlers\Api\PostHandler;
 use Infra\Http\Router;
 
 return function (Router $router) {
-    $router->post('/api/post', new PostHandler);
+    $router->post('/api/posts/{id}', new PostHandler);
 };

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "format": "vendor/bin/pint",
     "lint": "vendor/bin/phpstan analyze -l 9 app public infra",
-    "test": "vendor/bin/pest",
+    "test": "vendor/bin/pest --coverage",
     "ci": [
       "composer format",
       "composer lint",

--- a/infra/Http/Request.php
+++ b/infra/Http/Request.php
@@ -7,23 +7,26 @@ namespace Infra\Http;
 use Infra\Enums\HttpMethod;
 use RuntimeException;
 
-readonly class Request
+class Request
 {
+    /** @var string[] */
+    private array $params;
+
     /**
-     * @param  array<string, string>  $data
+     * @param  string[]  $data
      */
     public function __construct(
-        private string $path,
-        private HttpMethod $httpMethod,
-        //  @todo deal with routeParams private array $routeParams,
-
+        private readonly string $path,
+        private readonly HttpMethod $httpMethod,
         /**
          * @todo deal with queryParams/queryString private array $getRequestData,
          * @todo deal with formPost private array $postRequestData,
          * @todo for now they are bundled together in data. I'm sure is not a good way to deal with it
          */
-        private array $data,
-    ) {}
+        private readonly array $data,
+    ) {
+        $this->params = [];
+    }
 
     public static function createFromGlobals(): self
     {
@@ -104,5 +107,22 @@ readonly class Request
     public function getMethod(): HttpMethod
     {
         return $this->httpMethod;
+    }
+
+    /** @param  string[]  $params */
+    public function setParams(array $params): void
+    {
+        $this->params = $params;
+    }
+
+    /** @return  string[]  */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    public function getParam(string $key, mixed $default = null): mixed
+    {
+        return $this->params[$key] ?? $default;
     }
 }

--- a/infra/Http/Router.php
+++ b/infra/Http/Router.php
@@ -54,7 +54,9 @@ class Router
     public function handleRequest(): Response
     {
         try {
-            $response = $this->getRoute()->handle($this->request);
+            $route = $this->getRoute();
+            $this->request->setParams($route->getParams());
+            $response = $route->getHandler()->handle($this->request);
         } catch (NotFoundException) {
             $response = (new NotFoundHandler)->handle($this->request);
         }
@@ -65,11 +67,11 @@ class Router
     /**
      * @throws NotFoundException
      */
-    private function getRoute(): RequestHandlerInterface
+    private function getRoute(): Route
     {
         foreach ($this->routes as $route) {
             if ($route->match($this->request)) {
-                return $route->getHandler();
+                return $route;
             }
         }
 

--- a/tests/Unit/Http/RouteTest.php
+++ b/tests/Unit/Http/RouteTest.php
@@ -9,7 +9,6 @@ use Infra\Http\Route;
 use Infra\Interfaces\RequestHandlerInterface;
 
 describe('Matching Logic', function () {
-
     it('should correctly determine if a route matches a given request', function (bool $expected, string $routePath, HttpMethod $routeMethod, string $requestPath, HttpMethod $requestMethod) {
         $handler = new class implements RequestHandlerInterface
         {
@@ -38,10 +37,46 @@ describe('Matching Logic', function () {
             false, '/test', HttpMethod::GET, '/different-path', HttpMethod::POST,
         ],
     ]);
+
+    it('should match routes with parameters and extract them', function () {
+        $handler = new class implements RequestHandlerInterface
+        {
+            public function handle(Request $request): Response
+            {
+                return new Response;
+            }
+        };
+
+        $route = new Route('/users/{id}', HttpMethod::GET, $handler);
+        $request = new Request('/users/42', HttpMethod::GET, []);
+
+        expect($route->match($request))->toBeTrue()
+            ->and($route->getParams())->toEqual(['id' => '42']);
+
+        $routeWithMultipleParams = new Route('/posts/{year}/{month}', HttpMethod::GET, $handler);
+        $requestWithMultipleParams = new Request('/posts/2023/10', HttpMethod::GET, []);
+
+        expect($routeWithMultipleParams->match($requestWithMultipleParams))->toBeTrue()
+            ->and($routeWithMultipleParams->getParams())->toEqual(['year' => '2023', 'month' => '10']);
+    });
+
+    it('should not match routes with parameters if the path does not conform', function () {
+        $handler = new class implements RequestHandlerInterface
+        {
+            public function handle(Request $request): Response
+            {
+                return new Response;
+            }
+        };
+
+        $route = new Route('/users/{id}', HttpMethod::GET, $handler);
+        $request = new Request('/users', HttpMethod::GET, []); // Missing ID
+
+        expect($route->match($request))->toBeFalse();
+    });
 });
 
 describe('Handler Accessor', function () {
-
     it('should return the correct handler instance', function () {
         $handler = new class implements RequestHandlerInterface
         {

--- a/tests/Unit/Http/RouterTest.php
+++ b/tests/Unit/Http/RouterTest.php
@@ -52,6 +52,26 @@ describe('Request Handling', function () {
 
         expect($response->status)->toBe(404);
     });
+
+    it('should inject route parameters into the request object', function () {
+        $request = new Request('/users/123', HttpMethod::GET, []);
+        $router = new Router($request);
+
+        $handler = new class implements RequestHandlerInterface
+        {
+            public function handle(Request $request): Response
+            {
+                return new Response(200);
+            }
+        };
+
+        $router->get('/users/{id}', $handler);
+        $router->handleRequest();
+
+        expect($request)->not->toBeNull()
+            ->and($request->getParam('id'))->toBe('123')
+            ->and($request->getParams())->toBe(['id' => '123']);
+    });
 });
 
 describe('Route Registration', function () {


### PR DESCRIPTION
This PR introduces support for dynamic URL parameters (e.g., /users/{id}), a core feature for a modern routing system.

**Changes**:

-  Route: Now uses regex to parse paths and capture named parameters.•Router: Injects the captured parameters into the Request object.
-  Request: Updated to store and provide access to route parameters.
-  Tests: Added unit tests to cover the new parameter handling logic.

**Usage Example:**
1. Define a route with a parameter:
```PHP
$router->get('/users/{id}', new UserHandler());
```
2. Access the parameter in the handler:
```PHP
public function handle(Request $request): Response
{
    $userId = $request->getRouteParam('id');
    // ...
}
```
