### PR TITLE
feat/add-dto-request-support

### DIFF
--- a/app/Dtos/PostRequestDto.php
+++ b/app/Dtos/PostRequestDto.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Dtos;
+
+use Infra\Interfaces\RequestDtoInterface;
+
+class PostRequestDto implements RequestDtoInterface
+{
+    public function __construct(
+        public string $title,
+        public ?string $content = '',
+    ) {}
+
+    /**
+     * @param  string[]  $data
+     */
+    public static function fromRequestData(array $data): self
+    {
+        $title = $data['title'] ?? '';
+
+        $content = $data['content'] ?? '';
+
+        return new self($title, $content);
+    }
+}

--- a/app/Handlers/Api/PostHandler.php
+++ b/app/Handlers/Api/PostHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Handlers\Api;
 
+use App\Dtos\PostRequestDto;
 use Infra\Http\Request;
 use Infra\Http\Response;
 use Infra\Interfaces\RequestHandlerInterface;
@@ -13,7 +14,7 @@ class PostHandler implements RequestHandlerInterface
     public function handle(Request $request): Response
     {
         return Response::json([
-            'data' => $request->getData(),
+            'data' => $request->getData(PostRequestDto::class),
             'params' => $request->getParams(),
         ]);
     }

--- a/infra/Http/Request.php
+++ b/infra/Http/Request.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Infra\Http;
 
 use Infra\Enums\HttpMethod;
+use Infra\Interfaces\RequestDtoInterface;
 use RuntimeException;
 
 class Request
@@ -95,25 +96,18 @@ class Request
         return $headers;
     }
 
-    public function int(string $field): int
+    /**
+     * @template T of RequestDtoInterface
+     *
+     * @param  class-string<T>  $requestDto
+     * @return T
+     */
+    public function getData(string $requestDto): RequestDtoInterface
     {
-        return (int) $this->__get($field);
-    }
+        /** @var T $requestData */
+        $requestData = $requestDto::fromRequestData($this->data);
 
-    public function bool(string $field): bool
-    {
-        return (bool) $this->__get($field);
-    }
-
-    public function __get(string $field): string
-    {
-        return $this->data[$field] ?? '';
-    }
-
-    /** @return string[] */
-    public function getData(): array
-    {
-        return $this->data;
+        return $requestData;
     }
 
     public function getPath(): string

--- a/infra/Interfaces/RequestDtoInterface.php
+++ b/infra/Interfaces/RequestDtoInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Infra\Interfaces;
+
+interface RequestDtoInterface
+{
+    /**
+     * @param  string[]  $data
+     */
+    public static function fromRequestData(array $data): self;
+}

--- a/tests/Unit/app/Handlers/PostHandlerTest.php
+++ b/tests/Unit/app/Handlers/PostHandlerTest.php
@@ -11,7 +11,10 @@ use Infra\Http\Router;
 
 describe('Api', function () {
     it('should return a json response', function () {
-        $data = ['test' => 'data'];
+        $data = [
+            'title' => 'Test title',
+            'content' => 'Test content',
+        ];
         $params = ['id' => 1.1];
 
         $request = new Request("/api/posts/{$params['id']}", HttpMethod::POST, $data);

--- a/tests/Unit/infra/Http/RequestTest.php
+++ b/tests/Unit/infra/Http/RequestTest.php
@@ -38,42 +38,6 @@ describe('createFromGlobals', function () {
     });
 });
 
-describe('Data Handling', function () {
-    beforeEach(function () {
-        $this->data = [
-            'name' => 'John Doe',
-            'age' => '30',
-            'active' => 'true',
-        ];
-
-        $this->request = prepareRequest(data: $this->data);
-    });
-
-    it('should access request data as properties', function () {
-        expect($this->request->name)
-            ->toBeString()
-            ->toBe('John Doe');
-    });
-
-    it('should convert a data field to an integer', function () {
-        expect($this->request->int('age'))
-            ->toBeInt()
-            ->toBe(30);
-    });
-
-    it('should convert a data field to a boolean', function () {
-        expect($this->request->bool('active'))
-            ->toBeBool()
-            ->toBeTrue();
-    });
-
-    it('should return all data as an array', function () {
-        expect($this->request->getData())
-            ->toBeArray()
-            ->toBe($this->data);
-    });
-});
-
 describe('Getters', function () {
     it('should return the correct request path', function () {
         $request = prepareRequest(path: '/users/1');


### PR DESCRIPTION
Feat: Add Request DTO Support

This PR introduces support for Data Transfer Objects (DTOs) to type-hint and structure incoming request data.

Updated Request getData method to hydrates a DTO with request data. The PostHandler is updated to demonstrate this, and a feature test is included to verify the implementation. This change improves type safety and separation of concerns.