### PR TITLE
feat/add-support-to-handler-has-a-string-class

### DIFF
--- a/app/Routes/api.php
+++ b/app/Routes/api.php
@@ -6,5 +6,5 @@ use App\Handlers\Api\PostHandler;
 use Infra\Http\Router;
 
 return function (Router $router) {
-    $router->post('/api/posts/{id}', new PostHandler);
+    $router->post('/api/posts/{id}', PostHandler::class);
 };

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -6,5 +6,5 @@ use App\Handlers\Web\HomeHandler;
 use Infra\Http\Router;
 
 return function (Router $router) {
-    $router->get('/', new HomeHandler);
+    $router->get('/', HomeHandler::class);
 };

--- a/infra/Http/Request.php
+++ b/infra/Http/Request.php
@@ -96,18 +96,10 @@ class Request
         return $headers;
     }
 
-    /**
-     * @template T of RequestDtoInterface
-     *
-     * @param  class-string<T>  $requestDto
-     * @return T
-     */
+    /** @param  class-string<RequestDtoInterface>  $requestDto */
     public function getData(string $requestDto): RequestDtoInterface
     {
-        /** @var T $requestData */
-        $requestData = $requestDto::fromRequestData($this->data);
-
-        return $requestData;
+        return $requestDto::fromRequestData($this->data);
     }
 
     public function getPath(): string

--- a/infra/Http/Route.php
+++ b/infra/Http/Route.php
@@ -14,10 +14,11 @@ class Route
 
     private string $pattern;
 
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
     public function __construct(
         private readonly string $path,
         private readonly HttpMethod $method,
-        private readonly RequestHandlerInterface $handler
+        private readonly string|RequestHandlerInterface $handler
     ) {
         $this->params = [];
         $this->pattern = $this->compilePath();
@@ -30,7 +31,8 @@ class Route
         return '#^'.$pattern.'$#';
     }
 
-    public function getHandler(): RequestHandlerInterface
+    /** @return class-string<RequestHandlerInterface>|RequestHandlerInterface $handler */
+    public function getHandler(): string|RequestHandlerInterface
     {
         return $this->handler;
     }

--- a/infra/Http/Router.php
+++ b/infra/Http/Router.php
@@ -26,27 +26,32 @@ class Router
         private readonly Request $request,
     ) {}
 
-    public function get(string $path, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    public function get(string $path, string|RequestHandlerInterface $handler): void
     {
         $this->register($path, HttpMethod::GET, $handler);
     }
 
-    public function post(string $path, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    public function post(string $path, string|RequestHandlerInterface $handler): void
     {
         $this->register($path, HttpMethod::POST, $handler);
     }
 
-    public function put(string $path, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    public function put(string $path, string|RequestHandlerInterface $handler): void
     {
         $this->register($path, HttpMethod::PUT, $handler);
     }
 
-    public function patch(string $path, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    public function patch(string $path, string|RequestHandlerInterface $handler): void
     {
         $this->register($path, HttpMethod::PATCH, $handler);
     }
 
-    public function delete(string $path, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    public function delete(string $path, string|RequestHandlerInterface $handler): void
     {
         $this->register($path, HttpMethod::DELETE, $handler);
     }
@@ -56,7 +61,8 @@ class Router
         $this->get($from, new RedirectHandler($to, $status));
     }
 
-    private function register(string $path, HttpMethod $httpMethod, RequestHandlerInterface $handler): void
+    /** @param  class-string<RequestHandlerInterface>|RequestHandlerInterface  $handler */
+    private function register(string $path, HttpMethod $httpMethod, string|RequestHandlerInterface $handler): void
     {
         $this->routes[] = new Route($path, $httpMethod, $handler);
     }
@@ -65,8 +71,14 @@ class Router
     {
         try {
             $route = $this->getRoute();
+
             $this->request->setParams($route->getParams());
-            $response = $route->getHandler()->handle($this->request);
+
+            /** @var class-string<RequestHandlerInterface>|RequestHandlerInterface $handler */
+            $handler = $route->getHandler();
+            $response = is_string($handler)
+                ? (new $handler)->handle($this->request)
+                : $handler->handle($this->request);
         } catch (NotFoundException) {
             $response = (new NotFoundHandler)->handle($this->request);
         } catch (MethodNotAllowedException) {

--- a/tests/Unit/app/Handlers/HomeHandlerTest.php
+++ b/tests/Unit/app/Handlers/HomeHandlerTest.php
@@ -10,7 +10,7 @@ use Infra\Http\Response;
 use Infra\Http\Router;
 
 describe('Web', function () {
-    it('should return home page', function () {
+    it('returns a successful response for the home page', function () {
         $request = new Request('/', HttpMethod::GET, []);
         $router = new Router($request);
 

--- a/tests/Unit/app/Handlers/PostHandlerTest.php
+++ b/tests/Unit/app/Handlers/PostHandlerTest.php
@@ -10,7 +10,7 @@ use Infra\Http\Response;
 use Infra\Http\Router;
 
 describe('Api', function () {
-    it('should return a json response', function () {
+    it('returns a JSON response with data and params for a POST request', function () {
         $data = [
             'title' => 'Test title',
             'content' => 'Test content',

--- a/tests/Unit/infra/Http/EmitterTest.php
+++ b/tests/Unit/infra/Http/EmitterTest.php
@@ -6,7 +6,7 @@ use Infra\Http\Emitter;
 use Infra\Http\Response;
 
 describe('Emitter', function () {
-    it('should emit the status code, headers, and body from a response', function () {
+    it('emits the status code, headers, and body from a response', function () {
         $response = new Response(
             status: 404,
             body: '{"error":"Not Found"}',
@@ -24,7 +24,7 @@ describe('Emitter', function () {
         expect($output)->toBe('{"error":"Not Found"}');
     });
 
-    it('should handle a response with no headers and an empty body', function () {
+    it('handles a response with no headers and an empty body', function () {
         $response = new Response(status: 204, body: '', headers: []);
         $emitter = new Emitter;
 

--- a/tests/Unit/infra/Http/RequestTest.php
+++ b/tests/Unit/infra/Http/RequestTest.php
@@ -10,7 +10,7 @@ describe('createFromGlobals', function () {
         unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['HTTP_ACCEPT']);
     });
 
-    it('should create a request from globals', function () {
+    it('creates a Request instance from PHP superglobals', function () {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = '/test';
 
@@ -19,7 +19,7 @@ describe('createFromGlobals', function () {
         expect($request)->toBeInstanceOf(Request::class);
     });
 
-    it('should get accept headers from globals', function () {
+    it('extracts headers from PHP superglobals', function () {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = '/test';
         $_SERVER['HTTP_ACCEPT'] = 'application/json';
@@ -30,7 +30,7 @@ describe('createFromGlobals', function () {
             ->and($request->getHeaders())->toBe(['accept' => 'application/json']);
     });
 
-    it('should throw an exception if request method is not defined', function () {
+    it('throws a RuntimeException if REQUEST_METHOD is not defined', function () {
         $_SERVER['REQUEST_URI'] = '/test';
 
         expect(fn () => Request::createFromGlobals())
@@ -39,7 +39,7 @@ describe('createFromGlobals', function () {
 });
 
 describe('Getters', function () {
-    it('should return the correct request path', function () {
+    it('getPath returns the correct request path', function () {
         $request = prepareRequest(path: '/users/1');
 
         expect($request->getPath())
@@ -47,7 +47,7 @@ describe('Getters', function () {
             ->toBe('/users/1');
     });
 
-    it('should return the correct request method', function () {
+    it('getMethod returns the correct request method', function () {
         $request = prepareRequest(method: HttpMethod::POST);
 
         expect($request->getMethod())

--- a/tests/Unit/infra/Http/ResponseTest.php
+++ b/tests/Unit/infra/Http/ResponseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Infra\Http\Response;
 
 describe('Constructor', function () {
-    it('should create a response with default values', function () {
+    it('creates a response with default values', function () {
         $response = new Response;
 
         expect($response->getStatus())->toBe(200)
@@ -13,7 +13,7 @@ describe('Constructor', function () {
             ->and($response->getBody())->toBe('');
     });
 
-    it('should create a response with custom values', function () {
+    it('creates a response with custom values', function () {
         $response = new Response(
             status: 404,
             body: 'Not Found',
@@ -27,7 +27,7 @@ describe('Constructor', function () {
 });
 
 describe('JSON Factory', function () {
-    it('should create a JSON response with a 200 status by default', function () {
+    it('creates a JSON response with a 200 status by default', function () {
         $data = ['user' => 'John Doe', 'id' => 123];
         $response = Response::json($data);
 
@@ -36,7 +36,7 @@ describe('JSON Factory', function () {
             ->and($response->getBody())->toBe(json_encode($data));
     });
 
-    it('should create a JSON response with a custom status', function () {
+    it('creates a JSON response with a custom status', function () {
         $data = ['error' => 'Invalid input'];
         $response = Response::json($data, 422);
 
@@ -45,7 +45,7 @@ describe('JSON Factory', function () {
             ->and($response->getBody())->toBe(json_encode($data));
     });
 
-    it('should handle an empty array for a JSON response', function () {
+    it('handles an empty array for a JSON response', function () {
         $response = Response::json([]);
 
         expect($response->getBody())->toBe('[]');
@@ -53,7 +53,7 @@ describe('JSON Factory', function () {
 });
 
 describe('HTML Factory', function () {
-    it('should create an HTML response with a 200 status by default', function () {
+    it('creates an HTML response with a 200 status by default', function () {
         $html = '<h1>Hello, World!</h1>';
         $response = Response::html($html);
 
@@ -62,7 +62,7 @@ describe('HTML Factory', function () {
             ->and($response->getBody())->toBe($html);
     });
 
-    it('should create an HTML response with a custom status', function () {
+    it('creates an HTML response with a custom status', function () {
         $html = '<h1>Unauthorized</h1>';
         $response = Response::html($html, 401);
 

--- a/tests/Unit/infra/Http/RouteTest.php
+++ b/tests/Unit/infra/Http/RouteTest.php
@@ -63,4 +63,20 @@ describe('Handler Accessor', function () {
 
         expect($route->getHandler())->toBe($handler);
     });
+
+    it('accepts handlers as a class instance', function () {
+        $route = new Route('/test', HttpMethod::GET, new MockRequestHandler);
+
+        expect($route->getHandler())
+            ->toBeInstanceOf(MockRequestHandler::class)
+            ->toBeObject();
+    });
+
+    it('accepts handlers as a class string', function () {
+        $route = new Route('/test', HttpMethod::GET, MockRequestHandler::class);
+
+        expect($route->getHandler())
+            ->toBe(MockRequestHandler::class)
+            ->toBeString();
+    });
 });

--- a/tests/Unit/infra/Http/RouteTest.php
+++ b/tests/Unit/infra/Http/RouteTest.php
@@ -12,7 +12,7 @@ describe('Matching Logic', function () {
         $this->handler = new MockRequestHandler;
     });
 
-    it('should correctly determine if a route matches a given request', function (bool $expected, string $routePath, HttpMethod $routeMethod, string $requestPath, HttpMethod $requestMethod) {
+    it('matches a request based on path and method', function (bool $expected, string $routePath, HttpMethod $routeMethod, string $requestPath, HttpMethod $requestMethod) {
         $route = new Route($routePath, $routeMethod, $this->handler);
         $request = new Request($requestPath, $requestMethod, []);
 
@@ -33,7 +33,7 @@ describe('Matching Logic', function () {
         ],
     ]);
 
-    it('should match routes with parameters and extract them', function () {
+    it('matches routes with parameters and extracts them', function () {
         $route = new Route('/users/{id}', HttpMethod::GET, $this->handler);
         $request = new Request('/users/42', HttpMethod::GET, []);
 
@@ -47,7 +47,7 @@ describe('Matching Logic', function () {
             ->and($routeWithMultipleParams->getParams())->toEqual(['year' => '2023', 'month' => '10']);
     });
 
-    it('should not match routes with parameters if the path does not conform', function () {
+    it('does not match when parameters do not conform to the route', function () {
         $route = new Route('/users/{id}', HttpMethod::GET, $this->handler);
         $request = new Request('/users', HttpMethod::GET, []); // Missing ID
 
@@ -56,7 +56,7 @@ describe('Matching Logic', function () {
 });
 
 describe('Handler Accessor', function () {
-    it('should return the correct handler instance', function () {
+    it('returns the correct handler instance', function () {
         $handler = new MockRequestHandler(200, 'Handled');
 
         $route = new Route('/test', HttpMethod::GET, $handler);

--- a/tests/Unit/infra/Http/RouterTest.php
+++ b/tests/Unit/infra/Http/RouterTest.php
@@ -12,7 +12,7 @@ describe('Request Handling', function () {
         $this->handler = new MockRequestHandler;
     });
 
-    it('should handle a request and return a response from the correct handler', function () {
+    it('handles a request and returns a response from the correct handler', function () {
         $request = new Request('/found', HttpMethod::GET, []);
         $successHandler = new MockRequestHandler(200, 'Success');
         $router = new Router($request);
@@ -24,7 +24,7 @@ describe('Request Handling', function () {
             ->and($response->getBody())->toBe('Success');
     });
 
-    it('should return a 404 response when no route matches the request URI', function () {
+    it('returns a 404 response when no route matches the request URI', function () {
         $request = new Request('/not-found', HttpMethod::GET, []);
         $router = new Router($request);
 
@@ -33,7 +33,7 @@ describe('Request Handling', function () {
         expect($response->getStatus())->toBe(404);
     });
 
-    it('should return a 405 HTML response when the web path matches but the HTTP method does not', function () {
+    it('returns a 405 HTML response when the method does not match a web route', function () {
         $request = new Request('/test', HttpMethod::POST, []);
         $router = new Router($request);
         $router->get('/test', $this->handler);
@@ -44,7 +44,7 @@ describe('Request Handling', function () {
             ->and($response->getBody())->toBe('<h1>405 Method Not Allowed</h1>');
     });
 
-    it('should return a 405 JSON response when the api path matches but the HTTP method does not', function () {
+    it('returns a 405 JSON response when the method does not match an API route', function () {
         $request = new Request('/api/test', HttpMethod::POST, []);
         $router = new Router($request);
         $router->get('/api/test', $this->handler);
@@ -55,7 +55,7 @@ describe('Request Handling', function () {
             ->and($response->getBody())->toBe(json_encode(['error' => 'Method Not Allowed']));
     });
 
-    it('should inject route parameters into the request object', function () {
+    it('injects route parameters into the request object', function () {
         $request = new Request('/users/123', HttpMethod::GET, []);
         $router = new Router($request);
 
@@ -67,7 +67,7 @@ describe('Request Handling', function () {
             ->and($request->getParams())->toBe(['id' => 123]);
     });
 
-    it('should cast route parameter to string', function () {
+    it('casts route parameters to string', function () {
         $request = new Request('/users/clebson', HttpMethod::GET, []);
         $router = new Router($request);
 
@@ -79,7 +79,7 @@ describe('Request Handling', function () {
             ->and($request->getParam('id'))->toBeString();
     });
 
-    it('should cast route parameter to integer', function () {
+    it('casts route parameters to integer', function () {
         $request = new Request('/users/42', HttpMethod::GET, []);
         $router = new Router($request);
 
@@ -91,7 +91,7 @@ describe('Request Handling', function () {
             ->and($request->getParam('id'))->toBeInt();
     });
 
-    it('should cast route parameter to float', function () {
+    it('casts route parameters to float', function () {
         $request = new Request('/users/4.2', HttpMethod::GET, []);
         $router = new Router($request);
 
@@ -105,7 +105,7 @@ describe('Request Handling', function () {
 });
 
 describe('Route Registration', function () {
-    it('should correctly register and handle routes for all HTTP methods', function (HttpMethod $method, string $routerMethod) {
+    it('registers and handles routes for various HTTP methods', function (HttpMethod $method, string $routerMethod) {
         $request = new Request('/test', $method, []);
         $router = new Router($request);
         $handler = new MockRequestHandler(201, 'Created');
@@ -123,7 +123,7 @@ describe('Route Registration', function () {
         'DELETE' => [HttpMethod::DELETE, 'delete'],
     ]);
 
-    it('should handle a redirect and return a redirect response', function () {
+    it('handles a redirect and returns a redirect response', function () {
         $request = new Request('/old-path', HttpMethod::GET, []);
         $router = new Router($request);
         $router->redirect('/old-path', '/new-path', 301);


### PR DESCRIPTION
This pull request introduces a significant refactoring to the routing system, enabling the use of class strings for handler definitions. This change simplifies route declarations and improves performance by lazy-loading handlers. Additionally, the tests have been updated to reflect these changes and ensure the stability of the framework.